### PR TITLE
#10 --- Set marquee height for Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                         </tr>
                     </thead>
                 </table>
-                <marquee direction="up" scrollamount="1" scrolldelay="50">
+                <marquee direction="up" scrollamount="1" scrolldelay="50" height="250">
                     <table class="guide-table"  cellpadding="0" cellspacing="0">
                         <thead>
                             <tr>
@@ -59,7 +59,7 @@
     </div>
     <div class="about">
         <p class="yellow">TV Simulator '99</p>
-        <p><a href="http://github.com/zshall/program-guide">Version 0.3.2</a></p>
+        <p><a href="http://github.com/zshall/program-guide">Version 0.3.3</a></p>
         <p>Zach Hall, 2017</p>
         <p class="yellow">Credits</p>
         <p><a href="http://ariweinstein.com/prevue/index.php">Prevue reference software, information, and Curday.dat</a> by <a href="http://ariweinstein.com/">AriX</a>, other Prevue Guide forum members.</p>


### PR DESCRIPTION
Fixes #10.

The marquee JavaScript was using a height of 200px instead of using the height of the container, so I specified a marquee height attribute to make it use that instead.