### PR TITLE
OG slash after redirect path

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Simulator of a hotel television from the 1990's."/>
     <meta property="og:title" content="TV Simulator '99"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:url" content="http://zshall.github.io/program-guide"/>
+    <meta property="og:url" content="http://zshall.github.io/program-guide/"/>
     <meta property="og:image" content="http://zshall.github.io/program-guide/img/tvsim-ogimg.png"/>
     <link href="css/guide.css" rel="stylesheet" />
     <link rel='shortcut icon' type='image/x-icon' href='favicon.ico' />
@@ -61,7 +61,7 @@
     </div>
     <div class="about">
         <p class="yellow">TV Simulator '99</p>
-        <p><a href="http://github.com/zshall/program-guide">Version 0.5</a></p>
+        <p><a href="http://github.com/zshall/program-guide">Version 0.5.1</a></p>
         <p>Zach Hall, 2017</p>
         <p class="yellow">Credits</p>
         <p><a href="http://ariweinstein.com/prevue/index.php">Prevue reference software, information, and Curday.dat</a> by <a href="http://ariweinstein.com/">AriX</a>, other Prevue Guide forum members.</p>


### PR DESCRIPTION
Let's see if this fixes the Facebook debugger's error about redirect paths...