### PR TITLE
HTTPS in links

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <meta name="description" content="Simulator of a hotel television from the 1990's."/>
     <meta property="og:title" content="TV Simulator '99"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:url" content="http://zshall.github.io/program-guide/"/>
-    <meta property="og:image" content="http://zshall.github.io/program-guide/img/tvsim-ogimg.png"/>
+    <meta property="og:url" content="https://zshall.github.io/program-guide/"/>
+    <meta property="og:image" content="https://zshall.github.io/program-guide/img/tvsim-ogimg.png"/>
     <link href="css/guide.css" rel="stylesheet" />
     <link rel='shortcut icon' type='image/x-icon' href='favicon.ico' />
 </head>
@@ -61,7 +61,7 @@
     </div>
     <div class="about">
         <p class="yellow">TV Simulator '99</p>
-        <p><a href="http://github.com/zshall/program-guide">Version 0.5.1</a></p>
+        <p><a href="https://github.com/zshall/program-guide">Version 0.5.1</a></p>
         <p>Zach Hall, 2017</p>
         <p class="yellow">Credits</p>
         <p><a href="http://ariweinstein.com/prevue/index.php">Prevue reference software, information, and Curday.dat</a> by <a href="http://ariweinstein.com/">AriX</a>, other Prevue Guide forum members.</p>


### PR DESCRIPTION
Turns out Facebook was right to complain, as I was using `http` not `https` in my URLs.