### PR TITLE
#31 ---  Replaces removed YouTube commercial video with a new one

### DIFF
--- a/channels/012/script.js
+++ b/channels/012/script.js
@@ -19,7 +19,7 @@ class Channel12 extends Channel {
         this.player = new YT.Player('ytplayer', {
             height: '360',
             width: '425',
-            videoId: 'oemoqEuJdFE',
+            videoId: '9NSVU4Gv_wA',
             events: {
             'onReady': this.onPlayerReady,
             'onStateChange': this.onPlayerStateChange
@@ -178,7 +178,6 @@ class Channel12 extends Channel {
     // YouTube
     // The API will call this function when the video player is ready.
     onPlayerReady(event) {
-        tv.mute();
         event.target.playVideo();
     }
 

--- a/index.html
+++ b/index.html
@@ -26,12 +26,12 @@
     </div>
     <div class="about">
         <p class="yellow">TV Simulator '99</p>
-        <p><a href="https://github.com/zshall/program-guide">Version 0.6</a></p>
+        <p><a href="https://github.com/zshall/program-guide">Version 0.6.1</a></p>
         <p>Zach Hall, 2017</p>
         <p class="yellow">Credits</p>
         <p><a href="http://ariweinstein.com/prevue/index.php">Prevue reference software, information, and Curday.dat</a> by <a href="http://ariweinstein.com/">AriX</a>, other Prevue Guide forum members.</p>
         <p><a href="http://ariweinstein.com/prevue/viewtopic.php?f=2&t=449">New Prevue Fonts</a> by <a href="http://rudyv.io/">rudyvalencia</a></p>
-        <p><a href="https://www.youtube.com/watch?v=oemoqEuJdFE">4 Hours of 1990s Commercials</a> by <a href="https://www.youtube.com/channel/UC1IfPxiQ0-vAR02_PQwi-rQ">Vhs Archives</a></p>
+        <p><a href="https://www.youtube.com/watch?v=9NSVU4Gv_wA">90's Commercials Vol. 244</a> by <a href="https://www.youtube.com/channel/UCsoiFs_IAf8uMoXd7vj3_Gg">80sCommercialVault</a></p>
     </div>
 
     <!-- Load JS libraries -->


### PR DESCRIPTION
The video I had used from YouTube appears to have been removed when the account hosting it was either deleted or suspended. I've found a [new video](https://www.youtube.com/watch?v=9NSVU4Gv_wA) that has the same spirit of the original one, and am using that one now.

I also disabled the "mute on page load" code since it's unnecessary. I had it originally because I thought YouTube was blocking autoplaying content that wasn't muted. I've done more research and it appears that they don't block autoplay with sound if you're hosting the page on certain domains, and GitHub pages is one of those.